### PR TITLE
Fix .conf files creation on New world creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     "fabric-registry-sync-v0",
     "fabric-resource-loader-v0",
     "fabric-transitive-access-wideners-v1",
+    "fabric-lifecycle-events-v1",
   ).forEach { modImplementation(fabricApi.module(it, versions.fabricApi)) }
 
   modImplementation("me.shedaniel.cloth", "cloth-config-fabric", versions.clothConfig) {

--- a/src/main/java/com/jsorrell/carpetskyadditions/SkyAdditionsExtension.java
+++ b/src/main/java/com/jsorrell/carpetskyadditions/SkyAdditionsExtension.java
@@ -2,6 +2,8 @@ package com.jsorrell.carpetskyadditions;
 
 import carpet.CarpetExtension;
 import carpet.CarpetServer;
+import carpet.api.settings.CarpetRule;
+import carpet.api.settings.InvalidRuleValueException;
 import carpet.api.settings.SettingsManager;
 import carpet.utils.Translations;
 import com.jsorrell.carpetskyadditions.advancements.criterion.SkyAdditionsCriteriaTriggers;
@@ -9,7 +11,6 @@ import com.jsorrell.carpetskyadditions.advancements.predicates.SkyAdditionsLootI
 import com.jsorrell.carpetskyadditions.commands.SkyIslandCommand;
 import com.jsorrell.carpetskyadditions.config.SkyAdditionsConfig;
 import com.jsorrell.carpetskyadditions.gen.SkyBlockChunkGenerator;
-import com.jsorrell.carpetskyadditions.gen.SkyBlockStructures;
 import com.jsorrell.carpetskyadditions.gen.feature.SkyAdditionsFeatures;
 import com.jsorrell.carpetskyadditions.helpers.PiglinBruteSpawnPredicate;
 import com.jsorrell.carpetskyadditions.helpers.SkyAdditionsMinecartComparatorLogic;
@@ -17,10 +18,13 @@ import com.jsorrell.carpetskyadditions.settings.SkyAdditionsSettings;
 import com.jsorrell.carpetskyadditions.settings.SkyBlockDefaults;
 import com.jsorrell.carpetskyadditions.util.SkyAdditionsResourceLocation;
 import com.mojang.brigadier.CommandDispatcher;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.MinecartComparatorLogicRegistry;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
@@ -28,8 +32,6 @@ import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.SpawnPlacementTypes;
 import net.minecraft.world.entity.SpawnPlacements;
@@ -53,7 +55,13 @@ public class SkyAdditionsExtension implements CarpetExtension, ModInitializer {
     public void onInitialize() {
         settingsManager = new SettingsManager(MOD_VERSION, MOD_ID, MOD_NAME);
 
+        // Register SkyAdditions settings
+        settingsManager.parseSettingsClass(SkyAdditionsSettings.class);
+
         AutoConfig.register(SkyAdditionsConfig.class, Toml4jConfigSerializer::new);
+
+        // Register a server lifecycle event to handle configuration and settings
+        ServerLifecycleEvents.SERVER_STARTED.register(this::onServerStarted);
 
         // Restrict Piglin Brute spawning when piglinsSpawningInBastions is true
         SpawnPlacements.register(
@@ -62,14 +70,11 @@ public class SkyAdditionsExtension implements CarpetExtension, ModInitializer {
                 Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
                 new PiglinBruteSpawnPredicate());
 
-
-
         Registry.register(
-            BuiltInRegistries.CHUNK_GENERATOR,
-            new SkyAdditionsResourceLocation("skyblock").getResourceLocation(),
-            SkyBlockChunkGenerator.CODEC
+                BuiltInRegistries.CHUNK_GENERATOR,
+                new SkyAdditionsResourceLocation("skyblock").getResourceLocation(),
+                SkyBlockChunkGenerator.CODEC
         );
-
 
         SkyAdditionsFeatures.registerAll();
         SkyAdditionsCriteriaTriggers.registerAll();
@@ -78,9 +83,67 @@ public class SkyAdditionsExtension implements CarpetExtension, ModInitializer {
         SkyAdditionsDataPacks.register();
     }
 
+    private void onServerStarted(net.minecraft.server.MinecraftServer server) {
+        SkyAdditionsSettings.LOG.info("Server started. Processing configuration files and settings.");
+
+        // Write default configuration files
+        try {
+            Path configPath = server.getWorldPath(net.minecraft.world.level.storage.LevelResource.ROOT);
+            SkyBlockDefaults.writeDefaults(configPath);
+            SkyAdditionsSettings.LOG.info("Configuration files written successfully to: " + configPath);
+        } catch (IOException e) {
+            SkyAdditionsSettings.LOG.error("Failed to write configuration files.", e);
+        }
+
+        // Apply Carpet settings dynamically
+        applyCarpetRules(server);
+
+        // Apply SkyAdditions settings dynamically
+        applySkyAdditionsRules(server);
+    }
+
+    private void applyCarpetRules(net.minecraft.server.MinecraftServer server) {
+        CarpetServer.settingsManager.getCarpetRules().forEach(rule -> {
+            try {
+                if ("renewableSponges".equals(rule.name())) {
+                    rule.set(server.createCommandSourceStack(), "true");
+                    SkyAdditionsSettings.LOG.info("Set renewableSponges to true.");
+                } else if ("piglinsSpawningInBastions".equals(rule.name())) {
+                    rule.set(server.createCommandSourceStack(), "true");
+                    SkyAdditionsSettings.LOG.info("Set piglinsSpawningInBastions to true.");
+                }
+            } catch (Exception e) {
+                SkyAdditionsSettings.LOG.error("Failed to apply rule: " + rule.name(), e);
+            }
+        });
+        SkyAdditionsSettings.LOG.info("Default Carpet rules configured programmatically.");
+    }
+
+    private void applySkyAdditionsRules(net.minecraft.server.MinecraftServer server) {
+        SkyAdditionsSettings.getRules().forEach((ruleName, defaultValue) -> {
+            CarpetRule<?> rule = settingsManager.getCarpetRule(ruleName);
+            if (rule != null) {
+                try {
+                    rule.set(server.createCommandSourceStack(), defaultValue.toString());
+                    SkyAdditionsSettings.LOG.info("Set SkyAdditions rule: " + ruleName + " to " + defaultValue);
+                } catch (InvalidRuleValueException e) {
+                    SkyAdditionsSettings.LOG.error("Invalid value for SkyAdditions rule: " + ruleName, e);
+                }
+            } else {
+                SkyAdditionsSettings.LOG.warn("SkyAdditions rule not found: " + ruleName);
+            }
+        });
+        SkyAdditionsSettings.LOG.info("SkyAdditions rules applied dynamically.");
+    }
+
     @Override
     public void onGameStarted() {
         settingsManager.parseSettingsClass(SkyAdditionsSettings.class);
+
+        // Ensure rules are applied on game start
+        if (CarpetServer.minecraft_server != null) {
+            applySkyAdditionsRules(CarpetServer.minecraft_server);
+        }
     }
 
     @Override

--- a/src/main/java/com/jsorrell/carpetskyadditions/advancements/criterion/ConvertSpiderTrigger.java
+++ b/src/main/java/com/jsorrell/carpetskyadditions/advancements/criterion/ConvertSpiderTrigger.java
@@ -41,7 +41,11 @@ public class ConvertSpiderTrigger extends SimpleCriterionTrigger<ConvertSpiderTr
                         .apply(instance, ConvertSpiderTrigger.Conditions::new));
 
         public boolean matches(LootContext spiderContext, LootContext caveSpiderContext) {
-            return spider.get().matches(spiderContext) && caveSpider.get().matches(caveSpiderContext);
+                // Check if spider and caveSpider predicates are present and match their contexts
+                boolean spiderMatches = spider.map(predicate -> predicate.matches(spiderContext)).orElse(true);
+                boolean caveSpiderMatches = caveSpider.map(predicate -> predicate.matches(caveSpiderContext)).orElse(true);
+
+                return spiderMatches && caveSpiderMatches;
         }
     }
 }

--- a/src/main/java/com/jsorrell/carpetskyadditions/settings/SkyAdditionsSettings.java
+++ b/src/main/java/com/jsorrell/carpetskyadditions/settings/SkyAdditionsSettings.java
@@ -8,6 +8,9 @@ import carpet.api.settings.Rule;
 import carpet.api.settings.Validator;
 import carpet.api.settings.Validators;
 import com.jsorrell.carpetskyadditions.SkyAdditionsExtension;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import net.minecraft.commands.CommandSourceStack;
 import org.slf4j.Logger;
@@ -297,4 +300,36 @@ public class SkyAdditionsSettings {
             strict = false,
             validators = POSITIVE_NUMBER.class)
     public static int wanderingTraderSpawnRate = 24000;
+
+    /**
+     * Returns a map of all rules and their default values for dynamic application.
+     */
+    public static Map<String, Object> getRules() {
+        Map<String, Object> rules = new HashMap<>();
+        rules.put("coralErosion", true);
+        rules.put("allayableVexes", true);
+        rules.put("renewableDragonHeads", true);
+        rules.put("suspiciousSniffers", true);
+        rules.put("tallFlowersFromWanderingTrader", true);
+        rules.put("spreadingSmallDripleaves", true);
+        rules.put("spreadingCoral", true);
+        rules.put("shulkerSpawnsOnDragonKill", true);
+        rules.put("renewableSwiftSneak", true);
+        rules.put("traderCamels", true);
+        rules.put("renewableDeepslate", true);
+        rules.put("renewableNetherrack", true);
+        rules.put("lightningElectrifiesVines", true);
+        rules.put("renewableEchoShards", true);
+        rules.put("foxesSpawnWithSweetBerriesChance", 0.2);
+        rules.put("saplingsDieOnSand", true);
+        rules.put("renewableHeartsOfTheSea", true);
+        rules.put("renewableDiamonds", true);
+        rules.put("rammingWart", true);
+        rules.put("hugeMushroomsSpreadMycelium", true);
+        rules.put("renewableBuddingAmethysts", true);
+        rules.put("poisonousPotatoesConvertSpiders", true);
+        rules.put("sniffersFromDrowneds", true);
+        rules.put("gatewaysSpawnChorus", true);
+        return rules;
+    }
 }


### PR DESCRIPTION
I found an issue when creating a new world, the carpet.conf and carpetskyadditions.conf where not generated.
The change in this pull request should fix that (It works for me at least).
@TreeOfSelf I am working on this sniffer issue as well. I hope I am able to solve it, but I am a beginner java coder. :)

Now I see the convertspidertrigger in this pull request as well. I do not know how to remove it. Sorry.