### PR TITLE
Small update to the Coral advancement

### DIFF
--- a/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/max_coral_suitability.json
+++ b/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/max_coral_suitability.json
@@ -22,8 +22,15 @@
             "block": "minecraft:calcite"
           },
           {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "biomes": "minecraft:warm_ocean"
+            }
+          },
+          {
             "condition": "carpetskyadditions:location_check",
             "predicate": {
+              "coral_convertible": true,
               "coral_suitability": {
                 "min": 0.99
               }

--- a/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/spread_coral.json
+++ b/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/spread_coral.json
@@ -22,6 +22,12 @@
             "block": "minecraft:calcite"
           },
           {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "biomes": "minecraft:warm_ocean"
+            }
+          },
+          {
             "condition": "carpetskyadditions:location_check",
             "predicate": {
               "coral_convertible": true


### PR DESCRIPTION
Thanks for fixing the coral stuff. There was still some small issues with the advancements.

Spread coral advancement would actually be possible to get anywhere in the world as long as the 3x3 coral and calcite structure was built. Made a location predicate to limit it to warm ocean as this is the only place it should be possible.

max coral suitability was working, but as long as the coral_suitability was there, the only block needed was calcite. It's now changed to include the coral_convertible: true. Now the 3x3 structure is needed for this as well. Added the warm_ocean predicate as well, but do not know if it's needed in this one.