### PR TITLE
Removed obtainable items from wandering trader advancement

### DIFF
--- a/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/all_wandering_trader_trades.json
+++ b/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/all_wandering_trader_trades.json
@@ -230,18 +230,6 @@
         ]
       }
     },
-    "has_pink_petals": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:pink_petals"
-            ]
-          }
-        ]
-      }
-    },
     "has_acacia_sapling": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
@@ -381,18 +369,6 @@
           {
             "items": [
               "minecraft:pale_moss_block"
-            ]
-          }
-        ]
-      }
-    },
-    "has_open_eyeblossom": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:open_eyeblossom"
             ]
           }
         ]

--- a/src/main/resources/resourcepacks/skyblock_acacia/data/skyblock/advancements/progression/all_wandering_trader_trades.json
+++ b/src/main/resources/resourcepacks/skyblock_acacia/data/skyblock/advancements/progression/all_wandering_trader_trades.json
@@ -254,18 +254,6 @@
         ]
       }
     },
-    "has_pink_petals": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:pink_petals"
-            ]
-          }
-        ]
-      }
-    },
     "has_dark_oak_sapling": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
@@ -381,18 +369,6 @@
           {
             "items": [
               "minecraft:pale_moss_block"
-            ]
-          }
-        ]
-      }
-    },
-    "has_open_eyeblossom": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:open_eyeblossom"
             ]
           }
         ]


### PR DESCRIPTION
Removed two items from the wandering trader advancement as these are not exclusively obtainable from a wandering trader.

Pink Petals: Obtained by bone mealing a grass block in cherry grove biome. It's not a wandering trader trade anyway.

Open Eyeblossom: Can be obtained by bone mealing a grass block in pale garden biome.

