### PR TITLE
Sheep drop fix (MMH), Emerald fix (No Tree)

### DIFF
--- a/src/main/resources/resourcepacks/skyblock_mmh/data/more_mob_heads/loot_table/entities/sheep.json
+++ b/src/main/resources/resourcepacks/skyblock_mmh/data/more_mob_heads/loot_table/entities/sheep.json
@@ -1,359 +1,391 @@
 {
-  "type": "minecraft:entity",
-  "pools": [
-    {
-      "conditions": [
-				{
-					"condition": "killed_by_player"
-				}
-      ],
-      "rolls": 1.0,
-      "entries": [
+    "type": "minecraft:entity",
+    "pools": [
         {
-          "type": "minecraft:loot_table",
-          "value": "more_mob_heads:entities/sheep/jeb_"
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                }
+            ],
+            "rolls": 1.0,
+            "entries": [
+                {
+                    "type": "minecraft:loot_table",
+                    "value": "more_mob_heads:entities/sheep/jeb_"
+                }
+            ],
+            "functions": [
+                {
+                    "function": "minecraft:set_count",
+                    "count": 2
+                },
+                {
+                    "function": "minecraft:set_name",
+                    "entity": "this",
+                    "name": {
+                        "selector": "@s[name=jeb_]"
+                    }
+                },
+                {
+                    "function": "minecraft:filtered",
+                    "item_filter": {
+                        "components": {
+                            "minecraft:custom_name": ""
+                        }
+                    },
+                    "modifier": {
+                        "function": "minecraft:set_count",
+                        "count": 1
+                    }
+                },
+                {
+                    "function": "minecraft:set_count",
+                    "count": -1,
+                    "add": true
+                },
+                {
+                    "function": "minecraft:set_components",
+                    "components": {
+                        "!minecraft:custom_name": {}
+                    }
+                }
+            ]
+        },
+        {
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                }
+            ],
+            "rolls": 1.0,
+            "entries": [
+                {
+                    "type": "minecraft:alternatives",
+                    "children": [
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "white"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/white"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "orange"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/orange"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "magenta"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/magenta"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "light_blue"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/light_blue"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "yellow"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/yellow"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "lime"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/lime"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "pink"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/pink"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "gray"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/gray"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "light_gray"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/light_gray"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "cyan"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/cyan"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "purple"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/purple"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "blue"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/blue"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "brown"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/brown"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "green"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/green"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "red"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/red"
+                        },
+                        {
+                            "type": "minecraft:loot_table",
+                            "conditions": [
+                                {
+                                    "condition": "minecraft:entity_properties",
+                                    "entity": "this",
+                                    "predicate": {
+                                        "components": {
+                                            "minecraft:sheep/color": "black"
+                                        },
+                                        "type_specific": {
+                                            "type": "minecraft:sheep"
+                                        }
+                                    }
+                                }
+                            ],
+                            "value": "more_mob_heads:entities/sheep/black"
+                        }
+                    ]
+                }
+            ],
+            "functions": [
+                {
+                    "function": "minecraft:set_name",
+                    "entity": "this",
+                    "name": {
+                        "selector": "@s[name=jeb_]"
+                    }
+                },
+                {
+                    "function": "minecraft:filtered",
+                    "item_filter": {
+                        "components": {
+                            "minecraft:custom_name": ""
+                        }
+                    },
+                    "modifier": {
+                        "function": "minecraft:set_count",
+                        "count": 2
+                    }
+                },
+                {
+                    "function": "minecraft:set_count",
+                    "count": -1,
+                    "add": true
+                },
+                {
+                    "function": "minecraft:set_components",
+                    "components": {
+                        "!minecraft:custom_name": {}
+                    }
+                }
+            ]
         }
-      ],
-      "functions": [
-        {
-          "function": "minecraft:set_count",
-          "count": 2
-        },
-        {
-          "function": "minecraft:set_name",
-          "entity": "this",
-          "name": {
-            "selector": "@s[name=jeb_]"
-          }
-        },
-        {
-          "function": "minecraft:filtered",
-          "item_filter": {
-            "components": {
-              "minecraft:custom_name": "\"\""
-            }
-          },
-          "modifier": {
-            "function": "minecraft:set_count",
-            "count": 1
-          }
-        },
-        {
-          "function": "minecraft:set_count",
-          "count": -1,
-          "add": true
-        },
-        {
-          "function": "minecraft:set_components",
-          "components": {
-            "!minecraft:custom_name": {}
-          }
-        }
-      ]
-    },
-    {
-      "conditions": [
-				{
-					"condition": "killed_by_player"
-				}
-      ],
-      "rolls": 1.0,
-      "entries": [
-        {
-          "type": "minecraft:alternatives",
-          "children": [
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "white"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/white"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "orange"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/orange"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "magenta"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/magenta"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "light_blue"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/light_blue"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "yellow"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/yellow"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "lime"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/lime"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "pink"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/pink"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "gray"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/gray"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "light_gray"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/light_gray"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "cyan"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/cyan"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "purple"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/purple"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "blue"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/blue"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "brown"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/brown"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "green"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/green"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "red"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/red"
-            },
-            {
-              "type": "minecraft:loot_table",
-              "conditions": [
-                {
-                  "condition": "minecraft:entity_properties",
-                  "entity": "this",
-                  "predicate": {
-                    "type_specific": {
-                      "type": "minecraft:sheep",
-                      "color": "black"
-                    }
-                  }
-                }
-              ],
-              "value": "more_mob_heads:entities/sheep/black"
-            }
-          ]
-        }
-      ],
-      "functions": [
-        {
-          "function": "minecraft:set_name",
-          "entity": "this",
-          "name": {
-            "selector": "@s[name=jeb_]"
-          }
-        },
-        {
-          "function": "minecraft:filtered",
-          "item_filter": {
-            "components": {
-              "minecraft:custom_name": "\"\""
-            }
-          },
-          "modifier": {
-            "function": "minecraft:set_count",
-            "count": 2
-          }
-        },
-        {
-          "function": "minecraft:set_count",
-          "count": -1,
-          "add": true
-        },
-        {
-          "function": "minecraft:set_components",
-          "components": {
-            "!minecraft:custom_name": {}
-          }
-        }
-      ]
-    }
-  ],
-  "random_sequence": "more_mob_heads:entities/sheep"
+    ],
+    "random_sequence": "more_mob_heads:entities/sheep"
 }

--- a/src/main/resources/resourcepacks/skyblock_mmh/data/vanilla/loot_table/entities/sheep.json
+++ b/src/main/resources/resourcepacks/skyblock_mmh/data/vanilla/loot_table/entities/sheep.json
@@ -2,7 +2,7 @@
   "type": "minecraft:entity",
   "pools": [
     {
-      "bonus_rolls": 0.0,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -11,8 +11,8 @@
               "add": false,
               "count": {
                 "type": "minecraft:uniform",
-                "max": 2.0,
-                "min": 1.0
+                "max": 2,
+                "min": 1
               },
               "function": "minecraft:set_count"
             },
@@ -55,8 +55,8 @@
             {
               "count": {
                 "type": "minecraft:uniform",
-                "max": 1.0,
-                "min": 0.0
+                "max": 1,
+                "min": 0
               },
               "enchantment": "minecraft:looting",
               "function": "minecraft:enchanted_count_increase"
@@ -65,10 +65,10 @@
           "name": "minecraft:mutton"
         }
       ],
-      "rolls": 1.0
+      "rolls": 1
     },
     {
-      "bonus_rolls": 0.0,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -80,9 +80,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "white"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "white",
                       "sheared": false
                     }
                   }
@@ -97,9 +99,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "orange"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "orange",
                       "sheared": false
                     }
                   }
@@ -114,9 +118,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "magenta"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "magenta",
                       "sheared": false
                     }
                   }
@@ -131,9 +137,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "light_blue"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "light_blue",
                       "sheared": false
                     }
                   }
@@ -148,9 +156,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "yellow"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "yellow",
                       "sheared": false
                     }
                   }
@@ -165,9 +175,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "lime"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "lime",
                       "sheared": false
                     }
                   }
@@ -182,9 +194,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "pink"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "pink",
                       "sheared": false
                     }
                   }
@@ -199,9 +213,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "gray"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "gray",
                       "sheared": false
                     }
                   }
@@ -216,9 +232,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "light_gray"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "light_gray",
                       "sheared": false
                     }
                   }
@@ -233,9 +251,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "cyan"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "cyan",
                       "sheared": false
                     }
                   }
@@ -250,9 +270,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "purple"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "purple",
                       "sheared": false
                     }
                   }
@@ -267,9 +289,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "blue"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "blue",
                       "sheared": false
                     }
                   }
@@ -284,9 +308,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "brown"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "brown",
                       "sheared": false
                     }
                   }
@@ -301,9 +327,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "green"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "green",
                       "sheared": false
                     }
                   }
@@ -318,9 +346,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "red"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "red",
                       "sheared": false
                     }
                   }
@@ -335,9 +365,11 @@
                   "condition": "minecraft:entity_properties",
                   "entity": "this",
                   "predicate": {
+                    "components": {
+                      "minecraft:sheep/color": "black"
+                    },
                     "type_specific": {
                       "type": "minecraft:sheep",
-                      "color": "black",
                       "sheared": false
                     }
                   }
@@ -348,7 +380,7 @@
           ]
         }
       ],
-      "rolls": 1.0
+      "rolls": 1
     }
   ],
   "random_sequence": "minecraft:entities/sheep"

--- a/src/main/resources/resourcepacks/skyblock_no_tree/data/skyblock/advancement/progression/emerald.json
+++ b/src/main/resources/resourcepacks/skyblock_no_tree/data/skyblock/advancement/progression/emerald.json
@@ -1,0 +1,28 @@
+{
+  "parent": "skyblock:progression/dirt",
+  "display": {
+    "icon": {
+      "id": "minecraft:emerald"
+    },
+    "title": {
+      "translate": "Emerald City"
+    },
+    "description": {
+      "translate": "Get Emeralds from Foxes or archaeology"
+    }
+  },
+  "criteria": {
+    "has_emerald": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:emerald"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
I discovered that with More Mob Heads datapack activated, the sheeps only dropped _jeb head, and white wool. This update will fix that issue.
We had a good discussion about emeralds, and after that discussion I went through my datapacks to check updates for 1.21.9, and then I saw that the No Tree datapack was missing it's spesific emerald advancement. This will add it back as intended.

Let's continue the constructive discussions we have about this mod. :)