### PR TITLE
Add Modrinth badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Modrinth](https://img.shields.io/modrinth/v/Hi4jcyg4?style=flat-square&logo=modrinth&label=Modrinth)](https://modrinth.com/mod/carpetskyadditions-reborn)
+
 <img width="128" height="128" alt="image" src="https://github.com/user-attachments/assets/5e8be161-1902-48cb-97b8-8ec7c4192789" />
 
 


### PR DESCRIPTION
Makes it easier to find the Modrinth mod page from the repo. I also recommend linking to it from the repo's About section:

<img width="1986" height="98" alt="image" src="https://github.com/user-attachments/assets/2a3f0264-7557-4288-9e0c-732a8b5aef29" />