### PR TITLE
all lightning rod types convert vines to glow lichen (fix for post-1.21.9)

### DIFF
--- a/src/main/java/com/jsorrell/carpetskyadditions/helpers/LightningConverter.java
+++ b/src/main/java/com/jsorrell/carpetskyadditions/helpers/LightningConverter.java
@@ -3,6 +3,7 @@ package com.jsorrell.carpetskyadditions.helpers;
 import com.jsorrell.carpetskyadditions.settings.SkyAdditionsSettings;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.GlowLichenBlock;
@@ -15,7 +16,7 @@ public class LightningConverter {
         BlockState rawHitBlock = level.getBlockState(pos);
         BlockPos hitBlockPos;
         BlockState hitBlock;
-        if (rawHitBlock.is(Blocks.LIGHTNING_ROD)) {
+        if (rawHitBlock.is(BlockTags.LIGHTNING_RODS)) {
             hitBlockPos =
                     pos.relative(rawHitBlock.getValue(LightningRodBlock.FACING).getOpposite());
             hitBlock = level.getBlockState(hitBlockPos);


### PR DESCRIPTION
1.21.9 added oxidation stages and waxing to lightning rods, but the mod still only checks for the base lightning rod block at [LightningConverter.java#L18](https://github.com/TreeOfSelf/CarpetSkyAdditions-Reborn/blob/8b97b9396e58f3d350a417aa6046010a474cc911/src/main/java/com/jsorrell/carpetskyadditions/helpers/LightningConverter.java#L18).

Simply changed it to `rawHitBlock.is(BlockTags.LIGHTNING_RODS)` to check against all lightning rods regardless of oxidation stage and waxing.